### PR TITLE
Edit readme to say shell script works on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The texmf folder contains a number of folders, and these folders themselves cont
 
 # How to use it
 
+## Mac and Linux users
+
+Download the `.sh` script and run it.
+
+This may require first running `chmod +x mklocaltexmf.sh`.
+
+You are now ready to add any local additions you may have.
+
 ## Mac Users
 
 Download the `.zip` file which contains a clickable application.
@@ -50,12 +58,6 @@ Double click on the application, and it will show the following dialog box:
 Click on the "Take Me There" button, and a Finder window will open, like the one below: (shown in list view).
 
 ![Finder view](local-texmf-folder.png?raw=true "Finder")
-
-# Linux users
-
-Download the `.sh` script and run it.
-
-You are now ready to add any local additions you may have.
 
 ￼
 


### PR DESCRIPTION
As of macOs Catalina the application does not work.
The shell script does, however.
Edited the readme to say that mac users can use the shell script too so that they will try it out (rather than giving up when the application does not work).